### PR TITLE
Fixed dataloader in a3_gan_template.py

### DIFF
--- a/assignment_3/code/a3_gan_template.py
+++ b/assignment_3/code/a3_gan_template.py
@@ -86,8 +86,8 @@ def main():
         datasets.MNIST('./data/mnist', train=True, download=True,
                        transform=transforms.Compose([
                            transforms.ToTensor(),
-                           transforms.Normalize((0.5, 0.5, 0.5),
-                                                (0.5, 0.5, 0.5))])),
+                           transforms.Normalize((0.5,),
+                                                (0.5,))])),
         batch_size=args.batch_size, shuffle=True)
 
     # Initialize models and optimizers


### PR DESCRIPTION
Fixes a dataloader error: `RuntimeError: output with shape [1, 28, 28] doesn't match the broadcast shape [3, 28, 28]` 